### PR TITLE
About a small bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [riscv64]
-        rust-toolchain: [nightly, nightly-2025-01-18]
+        rust-toolchain: [nightly, nightly-2024-01-31]
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [riscv64]
-        rust-toolchain: [nightly, nightly-2024-01-31]
+        rust-toolchain: [nightly, nightly-2025-01-18]
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,6 @@ fn main() {
                 .arg(&format!("ARCH={}", arch))
                 .status()
                 .expect("failed to execute process: make lwext4");
-        
             retries -= 1; // 减少重试次数
         }
         assert!(status.success());

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
-
+use std::thread::sleep;
+use std::time::Duration;
 fn main() {
     let c_path = PathBuf::from("c/lwext4")
         .canonicalize()
@@ -31,12 +32,12 @@ fn main() {
         )
         .unwrap();
     }
-
+    let mut retries = 1;
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let lwext4_lib = &format!("lwext4-{}", arch);
     let lwext4_lib_path = &format!("c/lwext4/lib{}.a", lwext4_lib);
     if !Path::new(lwext4_lib_path).exists() {
-        let status = Command::new("make")
+        let mut status = Command::new("make")
             .args(&[
                 "musl-generic",
                 "-C",
@@ -45,6 +46,21 @@ fn main() {
             .arg(&format!("ARCH={}", arch))
             .status()
             .expect("failed to execute process: make lwext4");
+        while !status.success() && retries > 0 {
+            println!("Make failed, retrying in 2 seconds...");
+            sleep(Duration::new(2, 0)); // 等待 2 秒
+            status = Command::new("make")
+                .args(&[
+                    "musl-generic",
+                    "-C",
+                    c_path.to_str().expect("invalid path of lwext4"),
+                ])
+                .arg(&format!("ARCH={}", arch))
+                .status()
+                .expect("failed to execute process: make lwext4");
+        
+            retries -= 1; // 减少重试次数
+        }
         assert!(status.success());
 
         let cc = &format!("{}-linux-musl-gcc", arch);

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 use std::{env, fs};
 use std::thread::sleep;
 use std::time::Duration;
@@ -32,36 +32,40 @@ fn main() {
         )
         .unwrap();
     }
-    let mut retries = 1;
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let lwext4_lib = &format!("lwext4-{}", arch);
     let lwext4_lib_path = &format!("c/lwext4/lib{}.a", lwext4_lib);
     if !Path::new(lwext4_lib_path).exists() {
-        let mut status = Command::new("make")
+        let mut retries = 3; // 设置最大重试次数
+        let mut status: Result<ExitStatus, std::io::Error> = Command::new("make")
             .args(&[
                 "musl-generic",
                 "-C",
                 c_path.to_str().expect("invalid path of lwext4"),
             ])
             .arg(&format!("ARCH={}", arch))
-            .status()
-            .expect("failed to execute process: make lwext4");
-        while !status.success() && retries > 0 {
-            println!("Make failed, retrying in 2 seconds...");
-            sleep(Duration::new(2, 0)); // 等待 2 秒
-            status = Command::new("make")
-                .args(&[
-                    "musl-generic",
-                    "-C",
-                    c_path.to_str().expect("invalid path of lwext4"),
-                ])
-                .arg(&format!("ARCH={}", arch))
-                .status()
-                .expect("failed to execute process: make lwext4");
-            retries -= 1; // 减少重试次数
+            .status(); // 返回 Result 类型
+        
+        while let Err(_) = status {
+            if retries > 0 {
+                println!("Make failed, retrying in 2 seconds...");
+                sleep(Duration::new(2, 0)); // 等待 2 秒
+                status = Command::new("make")
+                    .args(&[
+                        "musl-generic",
+                        "-C",
+                        c_path.to_str().expect("invalid path of lwext4"),
+                    ])
+                    .arg(&format!("ARCH={}", arch))
+                    .status(); // 重新执行 make 命令
+                retries -= 1; // 减少重试次数
+            } else {
+                // 如果重试次数用完，还失败了
+                println!("Make failed after retries, aborting.");
+                panic!("failed to execute process: make lwext4");
+            }
         }
-        assert!(status.success());
-
+        
         let cc = &format!("{}-linux-musl-gcc", arch);
         let output = Command::new(cc)
             .args(["-print-sysroot"])


### PR DESCRIPTION
 
The intermittent issues may be caused by the use of the `spawn()` function, which executes asynchronously. So, we have at least two solutions: one is to remove `spawn()` and stop the asynchronous operation, and the other is to make the subsequent commands retry after sleeping for a while in case of failure. Since I am not sure whether the intermittent crashes are caused by this, I chose the latter method as the solution for submission.

Additionally, it seems that the workflow for this library is unable to set up the environment correctly.

